### PR TITLE
Fix reproducibility.

### DIFF
--- a/code/eda.py
+++ b/code/eda.py
@@ -92,7 +92,7 @@ def get_synonyms(word):
 			synonyms.add(synonym) 
 	if word in synonyms:
 		synonyms.remove(word)
-	return sorted(synonyms)
+	return random.shuffle(sorted(synonyms))
 
 ########################################################################
 # Random deletion

--- a/code/eda.py
+++ b/code/eda.py
@@ -64,7 +64,7 @@ from nltk.corpus import wordnet
 
 def synonym_replacement(words, n):
 	new_words = words.copy()
-	random_word_list = list(set([word for word in words if word not in stop_words]))
+	random_word_list = sorted(set([word for word in words if word not in stop_words]))
 	random.shuffle(random_word_list)
 	num_replaced = 0
 	for random_word in random_word_list:
@@ -92,7 +92,7 @@ def get_synonyms(word):
 			synonyms.add(synonym) 
 	if word in synonyms:
 		synonyms.remove(word)
-	return list(synonyms)
+	return sorted(synonyms)
 
 ########################################################################
 # Random deletion

--- a/code/eda.py
+++ b/code/eda.py
@@ -92,7 +92,10 @@ def get_synonyms(word):
 			synonyms.add(synonym) 
 	if word in synonyms:
 		synonyms.remove(word)
-	return random.shuffle(sorted(synonyms))
+	synonyms = sorted(synonyms)
+        shuffle(synonyms)
+        return synonyms
+
 
 ########################################################################
 # Random deletion


### PR DESCRIPTION
The order of words returned by list(set()) is not reproducible, even when the seed of random library is fixed. And this issue can be fixed by return a sorted list.